### PR TITLE
Make simulation results available as recarray  with lazy loading

### DIFF
--- a/pysces/PyscesModel.py
+++ b/pysces/PyscesModel.py
@@ -4215,6 +4215,9 @@ class PysMod(object):
         if self.__HAS_RATE_RULES__:
             s0_sim_init = numpy.concatenate([s0_sim_init, self.__rrule__])
 
+        # re-set self._sim recarray (otherwise self.sim is not updated)
+        self._sim = None
+        
         # real pluggable integration routines - brett 2007
         # the array copy is important ... brett leave it alone!
         Tsim0 = time.time()

--- a/pysces/PyscesModel.py
+++ b/pysces/PyscesModel.py
@@ -2490,6 +2490,7 @@ class PysMod(object):
         self.__StateOK__ = True
 
         self.data_sstate = None
+        self._sim = None            # new object for recarray with simulation results
         self.data_sim = None        # the new integration results data object
         self.data_stochsim = None        # the new stochastic integration results data object
         self.__scan2d_results__ = None # yaaaay gnuplot is back
@@ -4242,6 +4243,11 @@ class PysMod(object):
             print 'Simulation failure'
         del sim_res
 
+    @property
+    def sim(self):
+        if self._sim is None and self.data_sim is not None:
+            self._sim = numpy.rec.fromrecords(self.data_sim.getAllSimData(lbls=True)[0], names=self.data_sim.getAllSimData(lbls=True)[1])
+        return self._sim
 
     def State(self):
         """

--- a/pysces/PyscesModel.py
+++ b/pysces/PyscesModel.py
@@ -4249,7 +4249,8 @@ class PysMod(object):
     @property
     def sim(self):
         if self._sim is None and self.data_sim is not None:
-            self._sim = numpy.rec.fromrecords(self.data_sim.getAllSimData(lbls=True)[0], names=self.data_sim.getAllSimData(lbls=True)[1])
+            data = self.data_sim.getAllSimData(lbls=True)
+            self._sim = numpy.rec.fromrecords(data[0], names=data[1])
         return self._sim
 
     def State(self):


### PR DESCRIPTION
I have implemented the simulation results as a recarray `mod.sim` (much in the same way as for the `mod.scan` recarray). This is with lazy loading so the object is only created when it is called. This allows the user to conveniently access the simulation time and values of the variables:
`mod.Simulate()`
`mod.sim.Time`
`mod.sim.S1`
`mod.sim.R1`
etc.

These can then directly be used further in calculations or plotting. I have found this very useful in interactive work.