### PR TITLE
Default user directory location on Windows

### DIFF
--- a/pysces/PyscesConfig.py
+++ b/pysces/PyscesConfig.py
@@ -40,8 +40,8 @@ import os
 if os.sys.platform == 'win32':
     __DefaultWin = {
         "install_dir"  : os.path.join(os.sys.prefix,'lib','site-packages','pysces'),
-        "model_dir"    : "os.path.join(os.getenv('HOMEDRIVE')+os.path.sep,'Pysces','psc')",
-        "output_dir"   : "os.path.join(os.getenv('HOMEDRIVE')+os.path.sep,'Pysces')",
+        "model_dir"    : "os.path.join(os.getenv('USERPROFILE'),'Pysces','psc')",
+        "output_dir"   : "os.path.join(os.getenv('USERPROFILE'),'Pysces')",
         "gnuplot_dir"  : "None",
         "pitcon"       : True,
         "nleq2"        : True,
@@ -51,8 +51,8 @@ if os.sys.platform == 'win32':
         "silentstart"  : False
         }
     __DefaultWinUsr = {
-        "model_dir"    : os.path.join(os.getenv('HOMEDRIVE')+os.path.sep,'Pysces','psc'),
-        "output_dir"   : os.path.join(os.getenv('HOMEDRIVE')+os.path.sep,'Pysces'),
+        "model_dir"    : os.path.join(os.getenv('USERPROFILE'),'Pysces','psc'),
+        "output_dir"   : os.path.join(os.getenv('USERPROFILE'),'Pysces'),
         "silentstart"  : False
         }
 else:

--- a/pysces/__init__.py
+++ b/pysces/__init__.py
@@ -144,8 +144,8 @@ if os.sys.platform != 'win32':
         PyscesConfig.WriteConfig(os.path.join(os.path.expanduser('~'),'Pysces','.pys_usercfg.ini'),config=PyscesConfig.__DefaultPosixUsr, section='Pysces')
         __userdict = PyscesConfig.ReadConfig(os.path.join(os.path.expanduser('~'),'Pysces','.pys_usercfg.ini'), PyscesConfig.__DefaultPosixUsr)
 else:
-    if os.path.exists(os.path.join(os.getenv('HOMEDRIVE'),'Pysces','.pys_usercfg.ini')):
-        __userdict = PyscesConfig.ReadConfig(os.path.join(os.getenv('HOMEDRIVE'),'Pysces','.pys_usercfg.ini'), PyscesConfig.__DefaultWinUsr)
+    if os.path.exists(os.path.join(os.getenv('HOMEDRIVE')+os.path.sep,'Pysces','.pys_usercfg.ini')):
+        __userdict = PyscesConfig.ReadConfig(os.path.join(os.getenv('HOMEDRIVE')+os.path.sep,'Pysces','.pys_usercfg.ini'), PyscesConfig.__DefaultWinUsr)
     elif os.path.exists(os.path.join(os.getenv('USERPROFILE'),'Pysces','.pys_usercfg.ini')):
         __userdict = PyscesConfig.ReadConfig(os.path.join(os.getenv('USERPROFILE'),'Pysces','.pys_usercfg.ini'), PyscesConfig.__DefaultWinUsr)
     else:

--- a/pysces/__init__.py
+++ b/pysces/__init__.py
@@ -144,13 +144,15 @@ if os.sys.platform != 'win32':
         PyscesConfig.WriteConfig(os.path.join(os.path.expanduser('~'),'Pysces','.pys_usercfg.ini'),config=PyscesConfig.__DefaultPosixUsr, section='Pysces')
         __userdict = PyscesConfig.ReadConfig(os.path.join(os.path.expanduser('~'),'Pysces','.pys_usercfg.ini'), PyscesConfig.__DefaultPosixUsr)
 else:
-    if os.path.exists(os.path.join(os.getenv('HOMEDRIVE')+os.path.sep,'Pysces','.pys_usercfg.ini')):
-        __userdict = PyscesConfig.ReadConfig(os.path.join(os.getenv('HOMEDRIVE')+os.path.sep,'Pysces','.pys_usercfg.ini'), PyscesConfig.__DefaultWinUsr)
+    if os.path.exists(os.path.join(os.getenv('HOMEDRIVE'),'Pysces','.pys_usercfg.ini')):
+        __userdict = PyscesConfig.ReadConfig(os.path.join(os.getenv('HOMEDRIVE'),'Pysces','.pys_usercfg.ini'), PyscesConfig.__DefaultWinUsr)
+    elif os.path.exists(os.path.join(os.getenv('USERPROFILE'),'Pysces','.pys_usercfg.ini')):
+        __userdict = PyscesConfig.ReadConfig(os.path.join(os.getenv('USERPROFILE'),'Pysces','.pys_usercfg.ini'), PyscesConfig.__DefaultWinUsr)
     else:
-        if not os.path.exists(os.path.join(os.getenv('HOMEDRIVE')+os.path.sep,'Pysces')):
-            os.makedirs(os.path.join(os.getenv('HOMEDRIVE')+os.path.sep,'Pysces'))
-        PyscesConfig.WriteConfig(os.path.join(os.getenv('HOMEDRIVE')+os.path.sep,'Pysces','.pys_usercfg.ini'), config=PyscesConfig.__DefaultWinUsr, section='Pysces')
-        __userdict = PyscesConfig.ReadConfig(os.path.join(os.getenv('HOMEDRIVE')+os.path.sep,'Pysces','.pys_usercfg.ini'), PyscesConfig.__DefaultWinUsr)
+        if not os.path.exists(os.path.join(os.getenv('USERPROFILE'),'Pysces')):
+            os.makedirs(os.path.join(os.getenv('USERPROFILE'),'Pysces'))
+        PyscesConfig.WriteConfig(os.path.join(os.getenv('USERPROFILE'),'Pysces','.pys_usercfg.ini'), config=PyscesConfig.__DefaultWinUsr, section='Pysces')
+        __userdict = PyscesConfig.ReadConfig(os.path.join(os.getenv('USERPROFILE'),'Pysces','.pys_usercfg.ini'), PyscesConfig.__DefaultWinUsr)
 for key in __userdict:
     if key == 'output_dir':
         output_dir = __userdict[key]

--- a/setup.py
+++ b/setup.py
@@ -113,8 +113,8 @@ if os.sys.platform == 'win32':
         installdir = os.path.join(os.sys.prefix,'lib','site-packages','pysces')
     config = {
     "install_dir"  : installdir,
-    "model_dir"    : os.path.join(os.getenv('HOMEDRIVE')+os.path.sep,'Pysces','psc'),
-    "output_dir"   : os.path.join(os.getenv('HOMEDRIVE')+os.path.sep,'Pysces'),
+    "model_dir"    : os.path.join(os.getenv('USERPROFILE'),'Pysces','psc'),
+    "output_dir"   : os.path.join(os.getenv('USERPROFILE'),'Pysces'),
     "gnuplot_dir"  : None,
     "silentstart"  : False
     }


### PR DESCRIPTION
Move the default Pysces folder on win32 to `%USERPROFILE%\Pysces` (e.g. `C:\Users\<username>\Pysces`) instead of `%HOMEDRIVE%\Pysces` (e.g. `C:\Pysces`).

To ensure backward compatibility with legacy installations, upon package import the old location is first checked, and if the configuration file is present there, it is used so that the program functions as previously. Only when `C:\Pysces` is not found, a new user directory is created at `C:\Users\<username>\Pysces`.

This change makes sense to bring the Windows and Unix versions more in line with each other, and in addition the current default setup does allow not concurrent use by two different users on a Windows box. In addition "contaminating" the root of the system drive with user folders is not really elegant :grin:

This will have to be documented, I have not done so yet but can edit the docs once this pull request is accepted and merged.