### PR TITLE
Don't change CWD on startup

### DIFF
--- a/pysces/PyscesConfig.py
+++ b/pysces/PyscesConfig.py
@@ -49,11 +49,13 @@ if os.sys.platform == 'win32':
         "matplotlib": True,
         "matplotlib_backend": 'TKagg',
         "silentstart": False,
+        "change_dir_on_start": False,
     }
     __DefaultWinUsr = {
         "model_dir": os.path.join(os.getenv('USERPROFILE'), 'Pysces', 'psc'),
         "output_dir": os.path.join(os.getenv('USERPROFILE'), 'Pysces'),
         "silentstart": False,
+        "change_dir_on_start": False,
     }
 else:
     if hasattr(os.sys, 'lib'):
@@ -77,11 +79,13 @@ else:
         "matplotlib": True,
         "matplotlib_backend": 'TKagg',
         "silentstart": False,
+        "change_dir_on_start": False,
     }
     __DefaultPosixUsr = {
         "model_dir": os.path.join(os.path.expanduser('~'), 'Pysces', 'psc'),
         "output_dir": os.path.join(os.path.expanduser('~'), 'Pysces'),
         "silentstart": False,
+        "change_dir_on_start": False,
     }
     # OSX patch by AF
     if os.sys.platform == 'darwin':

--- a/pysces/PyscesModel.py
+++ b/pysces/PyscesModel.py
@@ -78,8 +78,14 @@ from . import (
     PyscesStoich,
     PyscesParse,
     __SILENT_START__,
+    __CHGDIR_ON_START__,
     SED,
 )
+
+if __CHGDIR_ON_START__:
+    CWD = OUTPUT_DIR
+else:
+    CWD = os.getcwd()
 
 interface = None
 
@@ -1092,7 +1098,7 @@ InfixParser.buildparser(
     debug=0, debugfile='infix.dbg', tabmodule='infix_tabmodule', outputdir=OUTPUT_DIR
 )
 InfixParser.setNameStr('self.', '')
-os.chdir(OUTPUT_DIR)
+os.chdir(CWD)
 
 # adapted from core2
 class Function(NewCoreBase):
@@ -1397,7 +1403,7 @@ class PysMod(object):
 
         self.__settings__ = {}
         self.__settings__.update({'enable_deprecated_attr': True})
-
+        self.WorkDir = CWD
         if loader == 'file':
             self.LoadFromFile(File, dir)
         elif loader == 'string':
@@ -1703,7 +1709,7 @@ class PysMod(object):
 
         print('\nParsing file: {}'.format(os.path.join(self.ModelDir, self.ModelFile)))
 
-        pscParser.ParsePSC(self.ModelFile, self.ModelDir, self.ModelOutput)
+        pscParser.ParsePSC(self.ModelFile, self.ModelDir, self.WorkDir)
         print(' ')
 
         badlist = pscParser.KeywordCheck(pscParser.ReactionIDs)
@@ -1887,7 +1893,6 @@ class PysMod(object):
                 assignment_rules[ar]['code_string'] = formula
                 all_names += InfixParser.names
 
-            os.chdir(self.ModelOutput)
             keep = []
             rules = list(assignment_rules.keys())
             dep = rules
@@ -1977,7 +1982,6 @@ class PysMod(object):
                 cntr += 1
                 # create mod.<rule name>_init attributes
                 setattr(self, '{}_init'.format(name), getattr(self, name))
-            os.chdir(self.ModelOutput)
             print('Rate rule(s) detected.')
         else:
             rr_code_block = 'pass\n'
@@ -2655,7 +2659,6 @@ class PysMod(object):
                 F.setArg(arg.strip())
             F.addFormula(self.__functions__[func]['formula'])
             setattr(self, func, F)
-        os.chdir(self.ModelOutput)
         for func in self.__functions__:
             fobj = getattr(self, func)
             for f in fobj.functions:
@@ -2675,7 +2678,6 @@ class PysMod(object):
                 ev.setAssignment(ass, self.__eDict__[e]['assignments'][ass])
             self.__events__.append(ev)
             setattr(self, ev.name, ev)
-        os.chdir(self.ModelOutput)
         if len(self.__events__) > 0:
             self.__HAS_EVENTS__ = True
             print('Event(s) detected.')
@@ -3364,7 +3366,6 @@ class PysMod(object):
             if warnings != '' and self.__settings__['display_compartment_warnings']:
                 print('\n# -- COMPARTMENT WARNINGS --')
                 print(warnings)
-        os.chdir(self.ModelOutput)
         if self.__settings__['display_debug'] == 1:
             print('vString')
             print(vString)

--- a/pysces/__init__.py
+++ b/pysces/__init__.py
@@ -141,6 +141,8 @@ for key in __config_dict:
             GNUPLOT_DIR = None
     elif key == 'silentstart':
         __SILENT_START__ = str2bool(__config_dict[key])
+    elif key == 'change_dir_on_start':
+        __CHGDIR_ON_START__ = str2bool(__config_dict[key])
 assert inipath != None, '\nNo configuration file found'
 
 if DEBUG:
@@ -217,8 +219,10 @@ for key in __userdict:
             GNUPLOT_DIR = None
     elif key == 'silentstart':
         __SILENT_START__ = str2bool(__userdict[key])
+    elif key == 'change_dir_on_start':
+        __CHGDIR_ON_START__ = str2bool(__userdict[key])
 assert output_dir != None, '\nNo output directory defined'
-assert model_dir != None, '\nNo output directory defined'
+assert model_dir != None, '\nNo model directory defined'
 
 # following is to get the full path when .pys_usercfg.ini specifies CWD as follows:
 # output_dir = ./
@@ -428,7 +432,6 @@ except ImportError as ex:
     SBML = None
     print(ex)
     print("INFO: No SBML library found, SBML support not available")
-
 
 # This has to come at the end
 from .PyscesModel import PysMod as model

--- a/pysces/core2/PyscesCore2.py
+++ b/pysces/core2/PyscesCore2.py
@@ -25,10 +25,11 @@ import os
 import math, operator
 import numpy
 
-CurrentDirectory = os.getcwd()  # temporary thing
-
-# this is a PySCeS specific hack
-from pysces import output_dir as CurrentDirectory
+from .. import output_dir, __CHGDIR_ON_START__
+if __CHGDIR_ON_START__:
+    CWD = output_dir
+else:
+    CWD = os.getcwd()
 
 from .InfixParser import MyInfixParser
 
@@ -38,12 +39,11 @@ InfixParser.buildparser(
     debug=0,
     debugfile='infix.dbg',
     tabmodule='infix_tabmodule',
-    outputdir=CurrentDirectory,
+    outputdir=output_dir,
 )
 InfixParser.setNameStr('self.', '()')
 
-# print 'CurrentDirectory', CurrentDirectory
-
+os.chdir(CWD)
 
 class MapList(list):
     def __init__(self, *args):

--- a/pysces/core2/PyscesCore2Interfaces.py
+++ b/pysces/core2/PyscesCore2Interfaces.py
@@ -26,10 +26,11 @@ from xml.etree import ElementTree
 import io
 import itertools
 
-CurrentDirectory = os.getcwd()  # temporary thing
-
-# this is a PySCeS specific hack
-from pysces import output_dir as CurrentDirectory
+from .. import output_dir, __CHGDIR_ON_START__
+if __CHGDIR_ON_START__:
+    CWD = output_dir
+else:
+    CWD = os.getcwd()
 
 from .InfixParser import MyInfixParser
 
@@ -39,12 +40,11 @@ InfixParser.buildparser(
     debug=0,
     debugfile='infix.dbg',
     tabmodule='infix_tabmodule',
-    outputdir=CurrentDirectory,
+    outputdir=output_dir,
 )
 InfixParser.setNameStr('self.', '()')
 
-# print 'CurrentDirectory', CurrentDirectory
-
+os.chdir(CWD)
 
 class CoreToPsc(object):
     core = None


### PR DESCRIPTION
As per #39 changing the current working directory is an unexpected side effect that largely stems from legacy PySCeS code at a time when the `HOME` environment variable was not properly defined under Windows. 

This PR introduces a new configuration option `change_dir_on_start = False` in `pyscfg.ini` as well as `.pys_usercfg.ini`. The default installation option is `False` but can be set to `True` in user configuration. When `False`, the current working directory is maintained upon importing pysces and loading a model. When set to `True`, the previous behaviour results, i.e. change directory to `$HOME/Pysces` after importing pysces and loading a model.

Note that the option to set the model directory and output directory to the current working directory still exists in `.pys_usercfg.ini`, as it has for some time already. This is for keeping PSC files in a folder related to a particular project and not in a central folder, by setting the options as follows:
```python
model_dir = ./
output_dir = ./
```