### PR TITLE
Add support for SBML L3 Events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+*.whl
 /packaging/many_linux/pip_cache
 .libs/
 

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -21,11 +21,6 @@
     "access_right": "open",
     "related_identifiers": [
         {
-            "scheme": "url",
-            "identifier": "https://github.com/PySCeS/pysces/tree/1.0.3",
-            "relation": "isSupplementTo"
-        },
-        {
             "scheme": "doi",
             "identifier": "10.5281/zenodo.2600905",
             "relation": "isVersionOf"

--- a/pysces/PyscesInterfaces.py
+++ b/pysces/PyscesInterfaces.py
@@ -48,8 +48,8 @@ class Core2interfaces(object):
     core2sbml = None
     core2psc = None
     sbml2core = None
-    sbml_level = 2
-    sbml_version = 1
+    sbml_level = 3
+    sbml_version = 2
 
     def __buildPscComponents__(self):
         """

--- a/pysces/PyscesModel.py
+++ b/pysces/PyscesModel.py
@@ -168,9 +168,10 @@ if _HAVE_ASSIMULO:
             # ev = self.events[idx]
             event = [self.events[j] for j in idx[0]]
             # priority = [self.events[j].priority for j in idx[0]]
-            sequence = setsequence(event)
+            sequence = self.setSequence(event)
             for ev in sequence:
                 if ev._assign_now:
+                    print(ev.name)
                     for ass in ev.assignments:
                         if ass.variable in self.mod.L0matrix.getLabels()[1] or (
                             self.mod.mode_integrate_all_odes
@@ -204,25 +205,24 @@ if _HAVE_ASSIMULO:
                 # track any parameter changes
                 self.parvals.append([getattr(self.mod, p) for p in self.mod.parameters])
 
-    def setsequence(event):
-        no_prio = [[x] for x in event if x.priority is None]
-        prio = [x for x in event if x.priority is not None]
+        def setSequence(self, event):
+            no_prio = [[x] for x in event if x.priority is None]
+            prio = [x for x in event if x.priority is not None]
 
-        sim = rndm.sample(prio, len(prio))
-        ev = sorted(sim, reverse=True, key=lambda x: x.priority)
-        fin = no_prio + [ev]
+            sim = rndm.sample(prio, len(prio))
+            ev = sorted(sim, reverse=True, key=lambda x: x.priority)
+            fin = no_prio + [ev]
 
-        sequence = ''
-        if not no_prio:
-            sequence = ev
-        elif not ev:
-            temp = rndm.sample(no_prio, len(no_prio))
-            sequence = [i for x in temp for i in x]
-        else:
-            temp = rndm.sample(fin, len(fin))
-            sequence = [i for x in temp for i in x]
+            if not no_prio:
+                sequence = ev
+            elif not ev:
+                temp = rndm.sample(no_prio, len(no_prio))
+                sequence = [i for x in temp for i in x]
+            else:
+                temp = rndm.sample(fin, len(fin))
+                sequence = [i for x in temp for i in x]
 
-        return sequence
+            return sequence
 
 # for future fun
 _HAVE_VPYTHON = False
@@ -1360,7 +1360,7 @@ class Event(NewCoreBase):
         self.assignments.append(ass)
         self.__setattr__('_' + var, ass)
 
-    def setpriority(self, priority):
+    def setPriority(self, priority):
         self.priority = priority
 
     def reset(self):
@@ -2764,7 +2764,7 @@ class PysMod(object):
             ev = Event(e, self)
             ev._time_symbol = self.__eDict__[e]['tsymb']
             ev.setTrigger(self.__eDict__[e]['trigger'], self.__eDict__[e]['delay'])
-            ev.setpriority(self.__eDict__[e]['priority'])
+            ev.setPriority(self.__eDict__[e]['priority'])
             # for each assignment
             for ass in self.__eDict__[e]['assignments']:
                 ev.setAssignment(ass, self.__eDict__[e]['assignments'][ass])

--- a/pysces/PyscesModel.py
+++ b/pysces/PyscesModel.py
@@ -68,6 +68,7 @@ from . import install_dir as INSTALL_DIR
 from . import PyscesRandom as random
 from .PyscesScan import Scanner
 from .core2.InfixParser import MyInfixParser
+from .core2.PyscesCore2 import NewCoreBase, NumberBase
 
 from . import (
     nleq2,
@@ -1096,50 +1097,10 @@ class IntegrationDataObj(object):
             return output, lout
 
 
-# this must stay in sync with core2
-class NewCoreBase(object):
-    """
-    Core2 base class, needed here as we use Core2 derived classes
-    in PySCes
-    """
-
-    name = None
-    __DEBUG__ = False
-
-    def getName(self):
-        return self.name
-
-    def setName(self, name):
-        self.name = name
-
-    def get(self, attr):
-        """Return an attribute whose name is str(attr)"""
-        return self.__getattribute__(attr)
-
-
-# this must stay in sync with core2
-class NumberBase(NewCoreBase):
-    """
-    Derived Core2 number class.
-    """
-
-    value = None
-    value_initial = None
-
-    def __call__(self):
-        return self.value
-
-    def getValue(self):
-        return self.value
-
-    def setValue(self, v):
-        self.value = v
-
-
 # Finally killed my lambda functions - brett07
 class ReactionObj(NewCoreBase):
     """
-    Defines a reaction with a KineticLaw *kl8, *formula* and *name* bound
+    Defines a reaction with a KineticLaw *kl*, *formula* and *name* bound
     to a model instance, *mod*.
     """
 

--- a/pysces/PyscesModel.py
+++ b/pysces/PyscesModel.py
@@ -212,21 +212,20 @@ if _HAVE_ASSIMULO:
                 self.parvals.append([getattr(self.mod, p) for p in self.mod.parameters])
 
         def setSequence(self, event):
-            no_prio = [[x] for x in event if x.priority is None]
+            no_prio = [x for x in event if x.priority is None]
             prio = [x for x in event if x.priority is not None]
 
             sim = rndm.sample(prio, len(prio))
             ev = sorted(sim, reverse=True, key=lambda x: x.priority)
-            fin = no_prio + [ev]
 
             if not no_prio:
                 sequence = ev
             elif not ev:
-                temp = rndm.sample(no_prio, len(no_prio))
-                sequence = [i for x in temp for i in x]
+                sequence = rndm.sample(no_prio, len(no_prio))
             else:
-                temp = rndm.sample(fin, len(fin))
-                sequence = [i for x in temp for i in x]
+                sequence = ev
+                for i in no_prio:
+                    sequence.insert(rndm.randint(0, len(ev)), i)
 
             return sequence
 

--- a/pysces/PyscesModel.py
+++ b/pysces/PyscesModel.py
@@ -44,7 +44,6 @@ import numpy
 import scipy
 import scipy.linalg
 import scipy.integrate
-import random
 ScipyDerivative = None
 HAVE_SCIPY_DERIV = False
 try:
@@ -96,7 +95,7 @@ del (
     random.getstate,
 )  # random.division,
 del random.randrange, random.Random, random.choice
-del random.sample, random.shuffle, random.jumpahead
+del random.shuffle, random.jumpahead   # random.sample
 del random.SystemRandom, random.WichmannHill, random.triangular
 # used by functions random.NV_MAGICCONST, random.SG_MAGICCONST, random.BPF, random.RECIP_BPF
 
@@ -171,7 +170,7 @@ if _HAVE_ASSIMULO:
             sequence = self.setSequence(event_list)
             for ev in sequence:
                 if ev._assign_now:
-                    print(ev.name)
+                    print('executing', ev.name)
                     for ass in ev.assignments:
                         ass.evaluateAssignment()
                         if ass.variable in self.mod.L0matrix.getLabels()[1] or (

--- a/pysces/PyscesModel.py
+++ b/pysces/PyscesModel.py
@@ -44,7 +44,7 @@ import numpy
 import scipy
 import scipy.linalg
 import scipy.integrate
-import random as rndm
+import random
 ScipyDerivative = None
 HAVE_SCIPY_DERIV = False
 try:
@@ -166,9 +166,9 @@ if _HAVE_ASSIMULO:
             idx = numpy.where(state_info == -1)
             # idx = state_info.index(-1)
             # ev = self.events[idx]
-            event = [self.events[j] for j in idx[0]]
+            event_list = [self.events[j] for j in idx[0]]
             # priority = [self.events[j].priority for j in idx[0]]
-            sequence = self.setSequence(event)
+            sequence = self.setSequence(event_list)
             for ev in sequence:
                 if ev._assign_now:
                     print(ev.name)
@@ -211,21 +211,21 @@ if _HAVE_ASSIMULO:
                 # track any parameter changes
                 self.parvals.append([getattr(self.mod, p) for p in self.mod.parameters])
 
-        def setSequence(self, event):
-            no_prio = [x for x in event if x.priority is None]
-            prio = [x for x in event if x.priority is not None]
+        def setSequence(self, event_list):
+            no_prio = [ev for ev in event_list if ev.priority is None]
+            prio = [ev for ev in event_list if ev.priority is not None]
 
-            sim = rndm.sample(prio, len(prio))
-            ev = sorted(sim, reverse=True, key=lambda x: x.priority)
+            random_prio_sample = random.sample(prio, len(prio))
+            prio_sorted = sorted(random_prio_sample, reverse=True, key=lambda x: x.priority)
 
             if not no_prio:
-                sequence = ev
-            elif not ev:
-                sequence = rndm.sample(no_prio, len(no_prio))
+                sequence = prio_sorted
+            elif not prio_sorted:
+                sequence = random.sample(no_prio, len(no_prio))
             else:
-                sequence = ev
+                sequence = prio_sorted
                 for i in no_prio:
-                    sequence.insert(rndm.randint(0, len(ev)), i)
+                    sequence.insert(random.randint(0, len(prio_sorted)), i)
 
             return sequence
 

--- a/pysces/PyscesModel.py
+++ b/pysces/PyscesModel.py
@@ -173,6 +173,7 @@ if _HAVE_ASSIMULO:
                 if ev._assign_now:
                     print(ev.name)
                     for ass in ev.assignments:
+                        ass.evaluateAssignment()
                         if ass.variable in self.mod.L0matrix.getLabels()[1] or (
                             self.mod.mode_integrate_all_odes
                             and ass.variable in self.mod.__species__
@@ -183,8 +184,11 @@ if _HAVE_ASSIMULO:
                                 solver.y[assIdx] = assVal * getattr(
                                     self.mod, self.mod.__CsizeAllIdx__[assIdx]
                                 )
+                                setattr(self.mod, ass.variable, assVal * getattr(
+                                    self.mod, self.mod.__CsizeAllIdx__[assIdx]))
                             else:
                                 solver.y[assIdx] = assVal
+                                setattr(self.mod, ass.variable, assVal)
                         elif (
                             not self.mod.mode_integrate_all_odes
                             and ass.variable in self.mod.L0matrix.getLabels()[0]
@@ -192,6 +196,7 @@ if _HAVE_ASSIMULO:
                             print(
                                 'Event assignment to dependent species consider setting "mod.mode_integrate_all_odes = True"'
                             )
+                            setattr(self.mod, ass.variable, ass.value)
                         elif (
                             self.mod.__HAS_RATE_RULES__ and ass.variable in self.mod.__rate_rules__
                         ):
@@ -202,6 +207,7 @@ if _HAVE_ASSIMULO:
                             setattr(self.mod, ass.variable, assVal)
                         else:
                             ass()
+                            setattr(self.mod, ass.variable, ass.value)
                 # track any parameter changes
                 self.parvals.append([getattr(self.mod, p) for p in self.mod.parameters])
 
@@ -1319,8 +1325,8 @@ class Event(NewCoreBase):
         if self.state0 and not self.state:
             self.state0 = self.state
         if not self.state0 and self.state:
-            for ass in self.assignments:
-                ass.evaluateAssignment()
+            # for ass in self.assignments:
+            #     ass.evaluateAssignment()
             self.state0 = self.state
             self._need_action = True
             self._ASS_TIME_ = time + self.delay

--- a/pysces/PyscesParse.py
+++ b/pysces/PyscesParse.py
@@ -791,7 +791,13 @@ class PySCeSParser:
         rawf = t[1].replace('Event:', '').lstrip()
         args = rawf[: rawf.find('{')].strip().split(',')
         name = args.pop(0)
-        delay = float(args.pop(-1))
+        delay = float(args.pop(1))
+        priority = ''
+        for i in [args.pop(-1).lstrip()]:
+            if i == 'None':
+                priority = None
+            else:
+                priority = int(i)
         trigger = ''
         for a in args:
             trigger = trigger + a + ','
@@ -811,6 +817,8 @@ class PySCeSParser:
                     'trigger': trigger,
                     'assignments': assignments,
                     'tsymb': None,
+                    'priority': priority
+
                 }
             }
         )

--- a/pysces/PyscesParse.py
+++ b/pysces/PyscesParse.py
@@ -790,9 +790,10 @@ class PySCeSParser:
         '''EventDec : EVENTDEC'''
         rawf = t[1].replace('Event:', '').lstrip()
         args = rawf[: rawf.find('{')].strip().split(',')
+        if len(args) == 3:    # append None priority if not specified (legacy support)
+            args.append('None')
         name = args.pop(0)
         delay = float(args.pop(1))
-        priority = ''
         for i in [args.pop(-1).lstrip()]:
             if i == 'None':
                 priority = None

--- a/pysces/core2/PyscesCore2.py
+++ b/pysces/core2/PyscesCore2.py
@@ -54,6 +54,10 @@ class MapList(list):
 
 
 class NewCoreBase(object):
+    """
+    Core2 base class
+    """
+
     __DEBUG__ = False
     name = None
     annotations = None
@@ -82,6 +86,10 @@ class NewCoreBase(object):
 
 
 class NumberBase(NewCoreBase):
+    """
+    Derived Core2 number class.
+    """
+
     value = None
     value_initial = None
 
@@ -794,6 +802,7 @@ class Event(NewCoreBase):
     _need_action = False
     _names = None
     _time_symbol = None
+    priority = None
 
     def __init__(self, name):
         self.setName(name)
@@ -840,7 +849,7 @@ class Event(NewCoreBase):
             self.formula = InfixParser.output
         self.xcode = compile(self.code_string, '<string>', 'exec')
         if self.__DEBUG__:
-            self.name, self.code_string
+            print(self.name, self.code_string)
 
     def setTriggerAttributes(self, core):
         # TODO: experimental
@@ -854,6 +863,8 @@ class Event(NewCoreBase):
         self.assignments.append(ass)
         self.__setattr__('_' + var.name, ass)
 
+    def setPriority(self, priority):
+        self.priority = priority
 
 class PieceWise(NewCoreBase):
     """
@@ -1437,6 +1448,7 @@ class NewCore(NewCoreBase):
         # associate model attributes with event
         # TODO: check that this still works
         ev.setTriggerAttributes(self)
+        ev.setPriority(e['priority'])
         ##  for n in ev._names:
         ##  setattr(ev, n, self.__getattribute__(n))
         # for each assignment

--- a/pysces/core2/PyscesCore2Interfaces.py
+++ b/pysces/core2/PyscesCore2Interfaces.py
@@ -1353,8 +1353,8 @@ class SbmlToCore(object):
         warn = []
         fatal = []
 
-        if self.model.getLevel() >  2:
-            warn.append('Model is encoded as SBML Level 3, PySCeS only officially supports L2V5.')
+        # if self.model.getLevel() >  2:
+        #     warn.append('Model is encoded as SBML Level 3, PySCeS only officially supports L2V5.')
         if self.model.getNumConstraints() > 0:
             fatal.append('PySCeS does not support Constraints.')
         if self.model.getNumInitialAssignments() > 0:

--- a/pysces/core2/PyscesCore2Interfaces.py
+++ b/pysces/core2/PyscesCore2Interfaces.py
@@ -601,8 +601,8 @@ class CoreToSBML(object):
     core = None
     name = None
     SBML = None
-    level = 2
-    version = 1
+    level = 3
+    version = 2
     model = None
     document = None
     time = None
@@ -1045,10 +1045,17 @@ class CoreToSBML(object):
             #print(self.SBML.formulaToL3String(ASTnode))
             ## set _TIME_ ASTnode tag to <csymbol> time
             #ASTnode = self.astSetCSymbolTime(ASTnode)
-
             tr = self.SBML.Trigger(self.level, self.version)
             tr.setMath(ASTnode)
             EV.setTrigger(tr)
+
+            # priority
+            if ev.priority is not None:
+                prio = self.SBML.Priority(self.level, self.version)
+                ASTnode = self.SBML.parseL3Formula(str(ev.priority))
+                prio.setMath(ASTnode)
+                EV.setPriority(prio)
+
             ea_cntr = 0
             for ass in ev.assignments:
                 #print('LOOKATME PARSE EVENTASSIGNMENT line 1003')
@@ -1424,6 +1431,11 @@ class SbmlToCore(object):
             name = self.getId(ev)
             trigger = ev.getTrigger()
             triggerf = self.sbmlFormulaToInfix(trigger.getMath())
+            priority = ev.getPriority()
+            if priority is not None:
+                priorityf = self.sbmlFormulaToInfix(priority.getMath())
+            else:
+                priorityf = None
 
             # check for csymbol time
             hasTimeS = self.searchForCsymbolTime(trigger.getMath())
@@ -1448,6 +1460,7 @@ class SbmlToCore(object):
                         'name': name,
                         'trigger': triggerf,
                         'delay': delay,
+                        'priority': priorityf,
                         'assignments': {},
                         'tsymb': tSymb,
                     }

--- a/pysces/core2/PyscesCore2Interfaces.py
+++ b/pysces/core2/PyscesCore2Interfaces.py
@@ -431,12 +431,11 @@ class CoreToPsc(object):
             if start:
                 out = '# Event definitions\n'
                 start = False
-            ##  formula = ev.code_string.split('=',1)
-            formula = ev.formula
-            out += 'Event: %s, %s, %s \n{\n' % (ev.name, formula, ev.delay)
+            out += 'Event: {}, {}, {}, {}'.format(ev.name, ev.formula, ev.delay, ev.priority)
+            out += ' {\n'
             for ass in ev.assignments:
-                out += '%s = %s\n' % (ass.variable.name, ass.formula)
-            out += '}\n'
+                out += '    {} = {}\n'.format(ass.variable.name, ass.formula)
+            out += '    }\n\n'
         if out != '':
             out += ' \n'
         self.event_block = out


### PR DESCRIPTION
During the 2nd semester of 2022 I supervised a bioinformatics Honours student (Hanri van Heerden) who worked on support for SBML L3 events in PySCeS. The following was implemented:
- handling of simultaneous events (i.e. triggered by the same trigger)
- implementation and handling of priorities as event attributes, which determine the order in which the events are to be executed (according to the SBML spec)

Implementation of the following attributes is still outstanding:
- `InitialValue` (currently hard coded to `True`)
- `Persistent` (currently hard coded to `True`)

SBML import and export (round tripping) works.

To implement this, the PSC input file syntax for events was expanded as follows:
```python
Event: name, trigger, delay, priority {
    event assignments
    }
```
The newly introduced `priority` attribute (integer or `None`) is optional to deal with legacy PSC files. If it is not specified, the event `priority` attribute is assigned to `None` in the model.

Example notebook and model files demonstrating the implementation are available [here](https://github.com/PySCeS/pyscesdev/tree/main/johann/L3_events). That repo also contains a copy of Hanri's Honours report for reference.