### PR TITLE
Add CI support for building PySCeS wheel on Win-ARM64

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-latest]
+        os: [ubuntu-latest, windows-latest, windows-11-arm, macos-13, macos-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -22,6 +22,17 @@ jobs:
         if: matrix.os == 'windows-latest'
         run: |
           choco install rtools -y --no-progress --force --version=4.0.0.20220206
+
+      - name: Install LLVM for Windows ARM64
+        if: matrix.os == 'windows-11-arm'
+        shell: pwsh
+        run: |
+          Invoke-WebRequest https://github.com/llvm/llvm-project/releases/download/llvmorg-20.1.8/LLVM-20.1.8-woa64.exe -UseBasicParsing -OutFile LLVM-woa64.exe
+          Start-Process -FilePath ".\LLVM-woa64.exe" -ArgumentList "/S" -Wait
+          echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          echo "CC=clang-cl" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "FC=flang-new" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+          echo "AR=llvm-ar" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: (macos-13) Ensure gfortran is in path
         if: matrix.os == 'macos-13'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,9 +76,10 @@ tracker = "https://github.com/PySCeS/pysces/issues"
 [tool.cibuildwheel]
 build = "cp313-* cp312-* cp311-* cp310-*"
 archs = "auto64"
-skip = "*musllinux* pp*"
+skip = "*musllinux* pp* cp310-win_arm64"
 build-verbosity = "3"
 test-command = "python -s -c \"import pysces; pysces.test(3)\""
+test-skip = "*-win_arm64" #Skip test suite for Win-ARM64 due unavailable test deps
 build-frontend="pip"
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
PR Description:

- The adoption of Windows on ARM (WoA) devices is steadily increasing, yet many Python wheels are still not available for this platform.
- GitHub Actions now offer native CI runners for Windows on ARM devices (windows-11-arm), enabling automated builds and testing.
- Currently, official PySCeS Python wheels are not provided for Windows ARM64 and thus users/developers were facing difficulties using popular PySCeS library natively.
- This PR introduces support for building PySCeS wheels on Windows ARM64, improving accessibility for developers and end users on this emerging platform.
- Currently, Python 3.10 builds are skipped since the corresponding Python binaries distributions are stopped officially for this platform and the test suite is skipped since there is no official scipy wheel available for Win-ARM64(expected by Sep 10).