### PR TITLE
Enable test suite for Windows ARM64

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,6 @@ archs = "auto64"
 skip = "*musllinux* pp* cp310-win_arm64"
 build-verbosity = "3"
 test-command = "python -s -c \"import pysces; pysces.test(3)\""
-test-skip = "*-win_arm64" #Skip test suite for Win-ARM64 due unavailable test deps
 build-frontend="pip"
 
 [tool.cibuildwheel.linux]


### PR DESCRIPTION
* SciPy for windows on arm is now available via Pypi site.
* Following up on issue https://github.com/PySCeS/pysces/issues/105, enable test suite on WoA